### PR TITLE
Fixed Typescript definitions for typescript@3.7.2.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,21 +7,21 @@ import {
   IAnyType,
 } from 'mobx-state-tree'
 
-type Constructor = new(...args: any[])=>any;
+type InstanceType_IfConstructor<T> = T extends new (...args: any) => infer R ? R : any;
 
-export declare type ModelDecorator<T extends Constructor> = T & Model<T> & PropertyDecorator
+export declare type ModelDecorator<T extends Function> = T & Model<T> & PropertyDecorator
 
-export declare interface Model<T extends Constructor> {
-  create(snapshot?: ModelSnapshotType<ModelProperties>, env?: any): IStateTreeNode<IType<any, unknown, any>> & InstanceType<T>
+export declare interface Model<T extends Function> {
+  create(snapshot?: ModelSnapshotType<ModelProperties>, env?: any): IStateTreeNode<IType<any, unknown, any>> & InstanceType_IfConstructor<T>
   is(thing: any): boolean
-  props<A extends Constructor & ModelProperties>(props: object): ModelDecorator<A>
-  actions<A extends Constructor & ModelActions>(fn: (self: Instance<this>) => A): ModelDecorator<A>
+  props<A extends (self: Instance<this>) => ModelProperties>(props: object): ModelDecorator<A>
+  actions<A extends (self: Instance<this>) => ModelActions>(fn: A): ModelDecorator<A>
 }
 
 export declare type ModelOptions = {
   auto: boolean,
 }
-export declare function model<T extends Constructor>(target: T): ModelDecorator<T>
+export declare function model<T extends Function>(target: T): ModelDecorator<T>
 export declare function model(name?: string, options?: ModelOptions): typeof model
 export declare function model(options?: ModelOptions): typeof model
 export declare function prop(...args: any[]): any

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,21 +4,24 @@ import {
   ModelSnapshotType,
   ModelActions,
   Instance,
+  IAnyType,
 } from 'mobx-state-tree'
 
-export declare type ModelDecorator<T extends Function> = T & Model<T> & PropertyDecorator
+type Constructor = new(...args: any[])=>any;
 
-export declare interface Model<T extends Function> {
+export declare type ModelDecorator<T extends Constructor> = T & Model<T> & PropertyDecorator
+
+export declare interface Model<T extends Constructor> {
   create(snapshot?: ModelSnapshotType<ModelProperties>, env?: any): IStateTreeNode<IType<any, unknown, any>> & InstanceType<T>
   is(thing: any): boolean
-  props<A extends ModelProperties>(props: object): ModelDecorator<A>
-  actions<A extends ModelActions>(fn: (self: Instance<this>) => A): ModelDecorator<A>
+  props<A extends Constructor & ModelProperties>(props: object): ModelDecorator<A>
+  actions<A extends Constructor & ModelActions>(fn: (self: Instance<this>) => A): ModelDecorator<A>
 }
 
 export declare type ModelOptions = {
   auto: boolean,
 }
-export declare function model<T extends Function>(target: T): ModelDecorator<T>
+export declare function model<T extends Constructor>(target: T): ModelDecorator<T>
 export declare function model(name?: string, options?: ModelOptions): typeof model
 export declare function model(options?: ModelOptions): typeof model
 export declare function prop(...args: any[]): any
@@ -114,4 +117,4 @@ export declare const types: {
   setter: typeof setter,
 }
 
-export declare function getMstType(type: any): IType
+export declare function getMstType(type: any): IAnyType

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "module": "commonjs",
     "allowJs": true,
     "target": "es6",
     "experimentalDecorators": true,


### PR DESCRIPTION
* Fixed Typescript definitions for typescript@3.7.2.

Details: `InstanceType<T>` is now defined by TypeScript as follows:
```
/**
 * Obtain the return type of a constructor function type
 */
type InstanceType<T extends new (...args: any) => any> = T extends new (...args: any) => infer R ? R : any;
```

The extends clause requires that the type-parameter be a constructor.

Since `InstanceType` was used by `Model.create` in `mst-decorators/src/index.d.ts`, I had to replace it with a looser version, that just returns `any` if the supplied type-parameter for `Model<T>` is a normal function instead of a constructor. (as is true for [this line in the tests](https://github.com/farwayer/mst-decorators/blob/master/test/ts/basic.ts#L285))